### PR TITLE
(re)start animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ The previous timestamp is also passed, which can be useful for calculating delta
 
 Cancels the current animation frame and ends the loop.
 
+#### `this.props.startAnimation()`
+
+Function to restart the animation after it was ended by `endAnimation`.
+
 
 ### Local development
 

--- a/src/AnimationFrameComponent.jsx
+++ b/src/AnimationFrameComponent.jsx
@@ -9,6 +9,7 @@ module.exports = function AnimationFrameComponent(InnerComponent, throttleMs) {
 
             this.loop = this.loop.bind(this);
             this.endAnimation = this.endAnimation.bind(this);
+            this.startAnimation = this.startAnimation.bind(this);
 
             this.state = {
                 isActive: true,
@@ -44,6 +45,16 @@ module.exports = function AnimationFrameComponent(InnerComponent, throttleMs) {
             });
         }
 
+        startAnimation() {
+            if (!this.state.isActive) {
+
+                this.setState({
+                    isActive: true,
+                    rafId: requestAnimationFrame(this.loop)
+                });
+            }
+        }
+
         componentDidMount() {
             if (!this.innerComponent.onAnimationFrame) {
                 throw new Error('The component passed to AnimationFrameComponent does not implement onAnimationFrame');
@@ -58,6 +69,7 @@ module.exports = function AnimationFrameComponent(InnerComponent, throttleMs) {
             return (
                 <InnerComponent ref={node => this.innerComponent = node}
                                 endAnimation={this.endAnimation}
+                                startAnimation={this.startAnimation}
                                 {...this.props} />
             );
         }

--- a/test/AnimationFrameComponentTests.jsx
+++ b/test/AnimationFrameComponentTests.jsx
@@ -103,6 +103,28 @@ describe('the RequestAnimationFrame HOC', function () {
         mockComponent.verify();
     });
 
+    it('should restart looping when the startAnimation method is invoked', function () {
+        mockComponent.expects('onAnimationFrame')
+            .twice()
+            .withArgs(sinon.match.number);
+
+        const WrappedComponent = AnimationFrameComponent(InnerComponent);
+        const renderedComponent = enzyme.mount(<WrappedComponent />);
+        const innerComponent = renderedComponent.find(InnerComponent);
+
+        mockRaf.step({ count: 1 });
+
+        innerComponent.prop('endAnimation')();
+
+        mockRaf.step({ count: 3 });
+
+        innerComponent.prop('startAnimation')();
+
+        mockRaf.step({ count: 1 });
+
+        mockComponent.verify();
+    });
+
     it('should throttle the invocation of the callback if specified', function (done) {
         this.timeout(4000);
 


### PR DESCRIPTION
I needed a way to animate stuff back and forth so I added a function to (re)start an animation. Not sure if that's the way to go, but it works for me. Maybe it works for others as well. Any feedback is very appreciated. I can also imagine this "feature" to be improved by an autoStart property for manually calling the `startAnimation` function that begin animating instead of starting on `componentDidMount`.

I have also included a test for this, although I'm not sure if that's the best way to test this functionality as I don't have any experience with mocha/sinon/enzyme/mock-raf